### PR TITLE
Add optional VAULT_SSH_CONFIG variable

### DIFF
--- a/ONVAULT
+++ b/ONVAULT
@@ -16,6 +16,9 @@ set -e
 # allow overriding default VAULT_SSH_KEY at runtime
 : ${VAULT_SSH_KEY:=id_rsa}
 
+# allow overriding default VAULT_SSH_CONFIG at runtime
+: ${VAULT_SSH_CONFIG:=config}
+
 # parse arguments
 while [[ "$#" > 1 ]]; do case $1 in
     --disable-pwd) DISABLE_PASSWORD="$2";;
@@ -59,6 +62,15 @@ if curl -s "${VAULT_URI}/_ping"; then
   curl -s "${VAULT_URI}/ssh.tgz" | tar -C ~/.ssh/ -zxf -
   chown -f `whoami` ~/.ssh/* || true
   chmod -f 600 ~/.ssh/* || true
+
+  log "Using ssh config file: $VAULT_SSH_CONFIG"
+  if [[  "$VAULT_SSH_CONFIG" != "config" ]]; then
+    # configure the ssh config file
+    if [[ -f "~/.ssh/config" ]]; then
+      cp -p ~/.ssh/config ~/.ssh/config.bak
+    fi
+    mv ~/.ssh/$VAULT_SSH_CONFIG ~/.ssh/config
+  fi
 
   log "Using ssh key: $VAULT_SSH_KEY"
   if [[  "$VAULT_SSH_KEY" != "id_rsa" ]]; then

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Some custom configurations are allowed through environment variables
 - `VAULT_PORT`: custom host+port for the vault server (example `tcp:172.17.0.1:14242`)
 - `VAULT_URI`: custom URI for the vault server (example `http://172.17.0.1:14242`)
 - `VAULT_SSH_KEY`: custom ssh key name used during `ONVAULT` command (example `id_rsa`)
+- `VAULT_SSH_CONFIG`: custom ssh config file used during `ONVAULT` command (example `config`)
 
 #### SSH config file
 
@@ -108,6 +109,9 @@ IdentityFile ~/.ssh/myprivatehost_key
 
 # otherwise will use the id_rsa key for any other host
 ```
+
+If platform-specific commands are in your `~/.ssh/config`, you can use the `VAULT_SSH_CONFIG` environment
+variable to specify an alternate file within the `~/.ssh` directory.
 
 #### SSH key password/passphrase
 


### PR DESCRIPTION
Currently there is no way to specify a non-standard `config` file in your `.ssh` directory.  If this variable , `VAULT_SSH_CONFIG`, is set to anything besides `config` it will copy the specified file over to `config` in the container.

The motivation behind this change is that it is possible on MacOS to use non-Linux directives in the `.ssh/config` file. These break when trying to use that same file in a Linux container. Therefore this mechanism was introduced to allow a separate file specifically for building these containers in Vault.

This is the same change as https://github.com/dockito/vault/pull/33