### PR TITLE
Quote the --disable-pwd argument to allow spaces

### DIFF
--- a/ONVAULT
+++ b/ONVAULT
@@ -79,7 +79,7 @@ if curl -s "${VAULT_URI}/_ping"; then
   fi
 
   if [[ "$DISABLE_PASSWORD" != "" ]]; then
-    ssh-keygen -p -P $DISABLE_PASSWORD -N "" -f ~/.ssh/$VAULT_SSH_KEY
+    ssh-keygen -p -P "$DISABLE_PASSWORD" -N "" -f ~/.ssh/$VAULT_SSH_KEY
   fi
 
   # restore 'no_proxy' for executing the actual command


### PR DESCRIPTION
If the user's password has a space in it, the `ssh-keygen` will complain about too many arguments.  Quote the variable `$DISABLE_PASSWORD` when pass it in.